### PR TITLE
[fix]: 删除可能造成后端启动失败的注释

### DIFF
--- a/frontend/embed.go
+++ b/frontend/embed.go
@@ -1,3 +1,4 @@
+
 package frontend
 
 import (
@@ -10,7 +11,6 @@ import (
 	"strings"
 )
 
-//go:embed dist/*
 var staticFiles embed.FS
 
 func InitFrontend(router *gin.Engine, relativePath string) {


### PR DESCRIPTION
解决问题：
在执行运行后go run main.go
可能会显示这个错误frontend/embed.go:13:12: pattern dist/*: no matching files found